### PR TITLE
Remove error recovery after updating a stack

### DIFF
--- a/sbt-aws-cfn/src/main/scala/com/chatwork/sbt/aws/cfn/SbtAwsCfn.scala
+++ b/sbt-aws-cfn/src/main/scala/com/chatwork/sbt/aws/cfn/SbtAwsCfn.scala
@@ -95,9 +95,6 @@ trait SbtAwsCfn extends SbtAwsS3 {
     val request = DescribeStacksRequestFactory.create().withStackName(stackName)
     client.describeStacksAsTry(request).map { result =>
       result.stacks
-    }.recoverWith {
-      case ex: AmazonServiceException if ex.getStatusCode == 400 =>
-        Success(Seq.empty)
     }
   }
 


### PR DESCRIPTION
Currently, the cfn module succeeds in update a stack whenever validation fails. To avoid this, I removed error recovery after updating a stack.
